### PR TITLE
Account scoping is added in guardpoint metric, hence we need to sum by guard_state for total count

### DIFF
--- a/provisioning/dashboards/ciphertrust-manager-cte-resources.json
+++ b/provisioning/dashboards/ciphertrust-manager-cte-resources.json
@@ -256,7 +256,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "ciphertrust_cte_management_cte_guardpoints{instance =~ \"$instances\"}",
+          "expr": "sum by(guard_state) (ciphertrust_cte_management_cte_guardpoints{instance =~ \"$instances\"})",
           "interval": "",
           "legendFormat": "{{guard_state}}",
           "refId": "A"


### PR DESCRIPTION
Now account scoping is added in guardpoint metric, hence we need to sum by guard_state for total count